### PR TITLE
Update to templates and change from manual edit of .txt to automatic.

### DIFF
--- a/my-ARK0-A3C.xml
+++ b/my-ARK0-A3C.xml
@@ -85,4 +85,5 @@
   <Config Name="DCP" Target="80" Default="" Mode="tcp" Description="dynamic config port" Type="Port" Display="always" Required="false" Mask="false">8080</Config>
   <Config Name="DCFB" Target="/serverdata/backup" Default="" Mode="rw" Description="Where to put the backups" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/backup</Config>
   <Config Name="Backup Days" Target="BACKUP_DAYS" Default="" Mode="" Description="Number of days to keep backups" Type="Variable" Display="always" Required="false" Mask="false">10</Config>
+  <Config Name="Dynamicconfig" Target="/dynamicconfig" Default="" Mode="rw" Description="" Type="Path" Display="always" Required="false" Mask="false">/mnt/cache/appdata/ark-se/dynamicconfig</Config>
 </Container>

--- a/my-ARK0-A3C.xml
+++ b/my-ARK0-A3C.xml
@@ -60,12 +60,12 @@
       <Mode/>
     </Variable>
     <Variable>
-      <Value>27025,27026,27027,27028,27029,27030,27031,27032,27033,27034</Value>
+      <Value>27035,27036,27037,27038,27039,27040,27041,27042,27043,27044,27045,27046</Value>
       <Name>MCRCON_PORTS</Name>
       <Mode/>
     </Variable>
     <Variable>
-      <Value>ARK1-TheIsland,ARK2-ScorchedEarth_P,ARK3-Aberration_P,ARK4-TheCenter,ARK5-Ragnarok,ARK6-Valguero_P,ARK7-CrystalIsles,ARK8-Extinction,ARK9-Genesis,ARK10-Genesis2</Value>
+      <Value>ARK1-TheIsland,ARK2-ScorchedEarth_P,ARK3-Aberration_P,ARK4-TheCenter,ARK5-Ragnarok,ARK6-Valguero_P,ARK7-CrystalIsles,ARK8-Extinction,ARK9-Genesis,ARK10-Genesis2,ARK11-LostIsland,ARK12-Fjordur</Value>
       <Name>CONTAINER_NAMES</Name>
       <Mode/>
     </Variable>

--- a/my-ARK1-TheIsland.xml
+++ b/my-ARK1-TheIsland.xml
@@ -52,8 +52,8 @@ You can also run multiple servers with only one SteamCMD directory!</Description
         <Protocol>udp</Protocol>
       </Port>
       <Port>
-        <HostPort>27025</HostPort>
-        <ContainerPort>27025</ContainerPort>
+        <HostPort>27035</HostPort>
+        <ContainerPort>27035</ContainerPort>
         <Protocol>tcp</Protocol>
       </Port>
     </Publish>
@@ -132,7 +132,7 @@ You can also run multiple servers with only one SteamCMD directory!</Description
       <Mode/>
     </Variable>
     <Variable>
-      <Value>?Port=7777?QueryPort=27015?MaxPlayers=10?RCONEnabled=True?RCONPort=27025?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
+      <Value>?Port=7777?QueryPort=27015?MaxPlayers=10?RCONEnabled=True?RCONPort=27035?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
       <Name>GAME_PARAMS</Name>
       <Mode/>
     </Variable>
@@ -162,12 +162,12 @@ You can also run multiple servers with only one SteamCMD directory!</Description
   <Config Name="UDP 1" Target="7777" Default="" Mode="udp" Description="UDP Gameport (if you need another port, please delete this entry and create a new UDP Port with the required port number, also don't forget to click an 'Show more settings ...' and change the port number" Type="Port" Display="always" Required="false" Mask="false">7777</Config>
   <Config Name="UDP 2" Target="7778" Default="" Mode="udp" Description="Container Port: 7778" Type="Port" Display="always" Required="false" Mask="false">7778</Config>
   <Config Name="UDP Steam" Target="27015" Default="" Mode="udp" Description="Container Port: 27015" Type="Port" Display="always" Required="false" Mask="false">27015</Config>
-  <Config Name="RCON TCP" Target="27025" Default="" Mode="tcp" Description="Container Port: 27025" Type="Port" Display="always" Required="false" Mask="false">27025</Config>
+  <Config Name="RCON TCP" Target="27035" Default="" Mode="tcp" Description="Container Port: 27035" Type="Port" Display="always" Required="false" Mask="false">27035</Config>
   <Config Name="Map" Target="MAP" Default="TheIsland" Mode="" Description="Container Variable: MAP" Type="Variable" Display="always-hide" Required="true" Mask="false">TheIsland</Config>
   <Config Name="Server Name" Target="SERVER_NAME" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">Your-TheIsland</Config>
   <Config Name="Server Password" Target="SRV_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false"/>
   <Config Name="Server Admin Password" Target="SRV_ADMIN_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">NotMyPassword</Config>
-  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7777?QueryPort=27015?MaxPlayers=10?RCONEnabled=True?RCONPort=27025?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
+  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7777?QueryPort=27015?MaxPlayers=10?RCONEnabled=True?RCONPort=27035?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
   <Config Name="Extra Game Parameters" Target="GAME_PARAMS_EXTRA" Default="" Mode="" Description="Type in your Extra Game Parameters seperated with a space and - (eg: -DisableDeathSpectator -UseBattlEye)" Type="Variable" Display="always-hide" Required="true" Mask="false">-server -log -automanagedmods -clusterid=YourCluster -ClusterDirOverride=/serverdata/serverfiles/clusterfiles -UseDynamicConfig</Config>
   <Config Name="Saved" Target="/serverdata/serverfiles/ShooterGame/Saved" Default="" Mode="rw" Description="container Path: /serverdata/serverfiles/ShooterGame/Saved a segregated space for saving arks and map specific config inis" Type="Path" Display="always" Required="false" Mask="false">/mnt/cache/appdata/ark-se/ARK1-TheIsland</Config>
   <Config Name="steamapps" Target="/serverdata/Steam/steamapps" Default="" Mode="rw" Description="mapping for workshop files to host steamcmd folder" Type="Path" Display="always" Required="false" Mask="false">/mnt/cache/appdata/steamcmd/steamapps</Config>

--- a/my-ARK10-Genesis2.xml
+++ b/my-ARK10-Genesis2.xml
@@ -52,8 +52,8 @@ You can also run multiple servers with only one SteamCMD directory!</Description
         <Protocol>udp</Protocol>
       </Port>
       <Port>
-        <HostPort>27034</HostPort>
-        <ContainerPort>27034</ContainerPort>
+        <HostPort>27044</HostPort>
+        <ContainerPort>27044</ContainerPort>
         <Protocol>tcp</Protocol>
       </Port>
     </Publish>
@@ -97,12 +97,12 @@ You can also run multiple servers with only one SteamCMD directory!</Description
       <Mode/>
     </Variable>
     <Variable>
-      <Value>TheIsland</Value>
+      <Value>Gen2</Value>
       <Name>MAP</Name>
       <Mode/>
     </Variable>
     <Variable>
-      <Value>Your-DangerIsland</Value>
+      <Value>Your-GenesisTwo</Value>
       <Name>SERVER_NAME</Name>
       <Mode/>
     </Variable>
@@ -117,7 +117,7 @@ You can also run multiple servers with only one SteamCMD directory!</Description
       <Mode/>
     </Variable>
     <Variable>
-      <Value>?Port=7795?QueryPort=27024?MaxPlayers=10?RCONEnabled=True?RCONPort=27034?CustomDynamicConfigUrl="http://172.17.0.2/dynamicconfig.ini"</Value>
+      <Value>?Port=7795?QueryPort=27024?MaxPlayers=10?RCONEnabled=True?RCONPort=27044?CustomDynamicConfigUrl="http://172.17.0.2/dynamicconfig.ini"</Value>
       <Name>GAME_PARAMS</Name>
       <Mode/>
     </Variable>
@@ -148,12 +148,12 @@ You can also run multiple servers with only one SteamCMD directory!</Description
   <Config Name="Server Name" Target="SERVER_NAME" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">Your-DangerIsland</Config>
   <Config Name="Server Password" Target="SRV_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false"/>
   <Config Name="Server Admin Password" Target="SRV_ADMIN_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">NotMyPassword</Config>
-  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7795?QueryPort=27024?MaxPlayers=10?RCONEnabled=True?RCONPort=27034?CustomDynamicConfigUrl="http://172.17.0.2/dynamicconfig.ini"</Config>
+  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7795?QueryPort=27024?MaxPlayers=10?RCONEnabled=True?RCONPort=27044?CustomDynamicConfigUrl="http://172.17.0.2/dynamicconfig.ini"</Config>
   <Config Name="Extra Game Parameters" Target="GAME_PARAMS_EXTRA" Default="" Mode="" Description="Type in your Extra Game Parameters seperated with a space and - (eg: -DisableDeathSpectator -UseBattlEye)" Type="Variable" Display="always-hide" Required="true" Mask="false">-server -log -clusterid=YourCluster -ClusterDirOverride=/serverdata/serverfiles/clusterfiles -UseDynamicConfig</Config>
   <Config Name="UDP 1" Target="7795" Default="" Mode="udp" Description="Container Port: 7795" Type="Port" Display="always" Required="false" Mask="false">7795</Config>
   <Config Name="UDP 2" Target="7796" Default="" Mode="udp" Description="Container Port: 7796" Type="Port" Display="always" Required="false" Mask="false">7796</Config>
   <Config Name="UDPSteam" Target="27024" Default="" Mode="udp" Description="Container Port: 27024" Type="Port" Display="always" Required="false" Mask="false">27024</Config>
-  <Config Name="TCPRCON" Target="27034" Default="" Mode="tcp" Description="Container Port: 27034" Type="Port" Display="always" Required="false" Mask="false">27034</Config>
+  <Config Name="TCPRCON" Target="27044" Default="" Mode="tcp" Description="Container Port: 27044" Type="Port" Display="always" Required="false" Mask="false">27044</Config>
   <Config Name="Saved" Target="/serverdata/serverfiles/ShooterGame/Saved" Default="" Mode="rw" Description="container Path: /serverdata/serverfiles/ShooterGame/Saved a segregated space for saving arks and map specific config inis" Type="Path" Display="always" Required="false" Mask="false">/mnt/cache/appdata/ark-se/ARK10-Genesis2</Config>
   <Config Name="UID" Target="UID" Default="" Mode="" Description="Container Variable: UID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">99</Config>
   <Config Name="GID" Target="GID" Default="" Mode="" Description="Container Variable: GID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">100</Config>

--- a/my-ARK11-LostIsland.xml
+++ b/my-ARK11-LostIsland.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <Container version="2">
-  <Name>ARK6-Valguero_P</Name>
+  <Name>ARK11-LostIsland</Name>
   <Repository>ich777/steamcmd:arkse</Repository>
   <Registry>https://hub.docker.com/r/ich777/steamcmd/</Registry>
   <Network>bridge</Network>
   <MyIP/>
-  <Shell>bash</Shell>
+  <Shell>sh</Shell>
   <Privileged>false</Privileged>
   <Support>https://forums.unraid.net/topic/79530-support-ich777-gameserver-dockers/</Support>
   <Project>https://survivetheark.com/</Project>
@@ -20,10 +20,10 @@ You can also run multiple servers with only one SteamCMD directory!</Overview>
   <WebUI/>
   <TemplateURL/>
   <Icon>https://raw.githubusercontent.com/ich777/docker-templates/master/ich777/images/arkse.png</Icon>
-  <ExtraParams>--restart=unless-stopped</ExtraParams>
+  <ExtraParams>--restart=unless-stopped </ExtraParams>
   <PostArgs/>
   <CPUset/>
-  <DateInstalled>1613444815</DateInstalled>
+  <DateInstalled>1613444660</DateInstalled>
   <DonateText>If you like my work please </DonateText>
   <DonateLink>https://www.paypal.me/chips777</DonateLink>
   <Description>This Docker will download and install SteamCMD. It will also install ARK:SurvivalEvolved and run it (Normal server startup of ARK can take a long time!).&#xD;
@@ -37,23 +37,23 @@ You can also run multiple servers with only one SteamCMD directory!</Description
     <Mode>bridge</Mode>
     <Publish>
       <Port>
-        <HostPort>7787</HostPort>
-        <ContainerPort>7787</ContainerPort>
+        <HostPort>7797</HostPort>
+        <ContainerPort>7797</ContainerPort>
         <Protocol>udp</Protocol>
       </Port>
       <Port>
-        <HostPort>7788</HostPort>
-        <ContainerPort>7788</ContainerPort>
+        <HostPort>7798</HostPort>
+        <ContainerPort>7798</ContainerPort>
         <Protocol>udp</Protocol>
       </Port>
       <Port>
-        <HostPort>27020</HostPort>
-        <ContainerPort>27020</ContainerPort>
+        <HostPort>27025</HostPort>
+        <ContainerPort>27025</ContainerPort>
         <Protocol>udp</Protocol>
       </Port>
       <Port>
-        <HostPort>27040</HostPort>
-        <ContainerPort>27040</ContainerPort>
+        <HostPort>27045</HostPort>
+        <ContainerPort>27045</ContainerPort>
         <Protocol>tcp</Protocol>
       </Port>
     </Publish>
@@ -70,12 +70,17 @@ You can also run multiple servers with only one SteamCMD directory!</Description
       <Mode>rw</Mode>
     </Volume>
     <Volume>
-      <HostDir>/mnt/cache/appdata/ark-se/ARK6-Valguero_P</HostDir>
+      <HostDir>/mnt/cache/appdata/ark-se/ARK11-LostIsland</HostDir>
       <ContainerDir>/serverdata/serverfiles/ShooterGame/Saved</ContainerDir>
       <Mode>rw</Mode>
     </Volume>
   </Data>
   <Environment>
+    <Variable>
+      <Value>376030</Value>
+      <Name>GAME_ID</Name>
+      <Mode/>
+    </Variable>
     <Variable>
       <Value/>
       <Name>USERNAME</Name>
@@ -92,12 +97,12 @@ You can also run multiple servers with only one SteamCMD directory!</Description
       <Mode/>
     </Variable>
     <Variable>
-      <Value>Valguero_P</Value>
+      <Value>LostIsland</Value>
       <Name>MAP</Name>
       <Mode/>
     </Variable>
     <Variable>
-      <Value>Your-Valguero</Value>
+      <Value>Your-LostIsland</Value>
       <Name>SERVER_NAME</Name>
       <Mode/>
     </Variable>
@@ -112,12 +117,12 @@ You can also run multiple servers with only one SteamCMD directory!</Description
       <Mode/>
     </Variable>
     <Variable>
-      <Value>?Port=7787?QueryPort=27020?MaxPlayers=10?RCONEnabled=True?RCONPort=27040?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
+      <Value>?Port=7797?QueryPort=27025?MaxPlayers=10?RCONEnabled=True?RCONPort=27045?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
       <Name>GAME_PARAMS</Name>
       <Mode/>
     </Variable>
     <Variable>
-      <Value>-server -log -nowrite -clusterid=YourCluster -ClusterDirOverride=/serverdata/serverfiles/clusterfiles -UseDynamicConfig </Value>
+      <Value>-server -log -clusterid=YourCluster -ClusterDirOverride=/serverdata/serverfiles/clusterfiles -UseDynamicConfig</Value>
       <Name>GAME_PARAMS_EXTRA</Name>
       <Mode/>
     </Variable>
@@ -131,31 +136,25 @@ You can also run multiple servers with only one SteamCMD directory!</Description
       <Name>GID</Name>
       <Mode/>
     </Variable>
-    <Variable>
-      <Value>376030</Value>
-      <Name>GAME_ID</Name>
-      <Mode/>
-    </Variable>
   </Environment>
   <Labels/>
   <Config Name="SteamCMD" Target="/serverdata/steamcmd" Default="" Mode="rw" Description="Container Path: /serverdata/steamcmd" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/steamcmd</Config>
   <Config Name="ServerFiles" Target="/serverdata/serverfiles" Default="" Mode="rw" Description="Container Path: /serverdata/serverfiles" Type="Path" Display="always" Required="true" Mask="false">/mnt/cache/appdata/ark-se</Config>
+  <Config Name="GAME_ID" Target="GAME_ID" Default="" Mode="" Description="The GAME_ID that the container download at startup.&#13;&#10;(https://developer.valvesoftware.com/wiki/Dedicated_Servers_List)" Type="Variable" Display="always" Required="true" Mask="false">376030</Config>
   <Config Name="Steam-Username" Target="USERNAME" Default="" Mode="" Description="Your Steam username goes here if you want to install a game that needs a valid account, otherwise leave it blank (ATTENTION: You have to disable Steam Guard)." Type="Variable" Display="always-hide" Required="false" Mask="false"/>
   <Config Name="Validate Installation" Target="VALIDATE" Default="" Mode="" Description="Set the Variable to 'true' if you want to validate the installation otherwise leave it blank." Type="Variable" Display="always-hide" Required="false" Mask="false"/>
   <Config Name="Steam-Password" Target="PASSWRD" Default="" Mode="" Description="Your Steam password goes here if you want to install a game that needs a valid account, otherwise leave it blank (ATTENTION: You have to disable Steam Guard)." Type="Variable" Display="always-hide" Required="false" Mask="true"/>
-  <Config Name="Map" Target="MAP" Default="TheIsland" Mode="" Description="Container Variable: MAP" Type="Variable" Display="always-hide" Required="true" Mask="false">Valguero_P</Config>
-  <Config Name="Server Name" Target="SERVER_NAME" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">Your-Valguero</Config>
+  <Config Name="Map" Target="MAP" Default="TheIsland" Mode="" Description="Container Variable: MAP" Type="Variable" Display="always-hide" Required="true" Mask="false">LostIsland</Config>
+  <Config Name="Server Name" Target="SERVER_NAME" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">Your-LostIsland</Config>
   <Config Name="Server Password" Target="SRV_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false"/>
   <Config Name="Server Admin Password" Target="SRV_ADMIN_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">NotMyPassword</Config>
-  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7787?QueryPort=27020?MaxPlayers=10?RCONEnabled=True?RCONPort=27040?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
-  <Config Name="Extra Game Parameters" Target="GAME_PARAMS_EXTRA" Default="" Mode="" Description="Type in your Extra Game Parameters seperated with a space and - (eg: -DisableDeathSpectator -UseBattlEye)" Type="Variable" Display="always-hide" Required="true" Mask="false">-server -log -nowrite -clusterid=YourCluster -ClusterDirOverride=/serverdata/serverfiles/clusterfiles -UseDynamicConfig </Config>
-  <Config Name="UDP 1" Target="7787" Default="" Mode="udp" Description="Container Port: 7787" Type="Port" Display="always" Required="false" Mask="false">7787</Config>
-  <Config Name="UDP 2" Target="7788" Default="" Mode="udp" Description="Container Port: 7788" Type="Port" Display="always" Required="false" Mask="false">7788</Config>
-  <Config Name="UDPSteam" Target="27020" Default="" Mode="udp" Description="Container Port: 27020" Type="Port" Display="always" Required="false" Mask="false">27020</Config>
-  <Config Name="TCPRCON" Target="27040" Default="" Mode="tcp" Description="Container Port: 27040" Type="Port" Display="always" Required="false" Mask="false">27040</Config>
-  <Config Name="ClusterID" Target="CLUSTERID" Default="" Mode="" Description="Name of the cluster this ARK should be a part of. &#13;&#10; Requires the ClusterFlies host path of all ARKs to be the same so they can pass player files back and forth." Type="Variable" Display="always" Required="false" Mask="false">YourCluster</Config>
-  <Config Name="ARK Save and Configs" Target="/serverdata/serverfiles/ShooterGame/Saved" Default="" Mode="rw" Description="container Path: /serverdata/serverfiles/ShooterGame/Saved &#13;&#10;A segregated space for separating ARK saves and  config ini's when creating a cluster example: /mnt/cache/appdata/ark-se/ARK1-TheIsland" Type="Path" Display="always" Required="false" Mask="false">/mnt/cache/appdata/ark-se/ARK6-Valguero_P</Config>
+  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7797?QueryPort=27025?MaxPlayers=10?RCONEnabled=True?RCONPort=27045?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
+  <Config Name="Extra Game Parameters" Target="GAME_PARAMS_EXTRA" Default="" Mode="" Description="Type in your Extra Game Parameters seperated with a space and - (eg: -DisableDeathSpectator -UseBattlEye)" Type="Variable" Display="always-hide" Required="true" Mask="false">-server -log  -clusterid=YourCluster -ClusterDirOverride=/serverdata/serverfiles/clusterfiles -UseDynamicConfig</Config>
+  <Config Name="UDP 1" Target="7779" Default="" Mode="udp" Description="Container Port: 7797" Type="Port" Display="always" Required="false" Mask="false">7797</Config>
+  <Config Name="UDP 2" Target="7780" Default="" Mode="udp" Description="Container Port: 7798" Type="Port" Display="always" Required="false" Mask="false">7798</Config>
+  <Config Name="UDPSteam" Target="27025" Default="" Mode="udp" Description="Container Port: 27025" Type="Port" Display="always" Required="false" Mask="false">27025</Config>
+  <Config Name="TCPRCON" Target="27045" Default="" Mode="tcp" Description="Container Port: 27045" Type="Port" Display="always" Required="false" Mask="false">27045</Config>
+  <Config Name="Saved" Target="/serverdata/serverfiles/ShooterGame/Saved" Default="" Mode="rw" Description="segregated space for saving arks and map specific config inis" Type="Path" Display="always" Required="false" Mask="false">/mnt/cache/appdata/ark-se/ARK11-LostIsland</Config>
   <Config Name="UID" Target="UID" Default="" Mode="" Description="Container Variable: UID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">99</Config>
   <Config Name="GID" Target="GID" Default="" Mode="" Description="Container Variable: GID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">100</Config>
-  <Config Name="GAME_ID" Target="GAME_ID" Default="" Mode="" Description="The GAME_ID that the container download at startup.&#13;&#10;(https://developer.valvesoftware.com/wiki/Dedicated_Servers_List)" Type="Variable" Display="advanced-hide" Required="true" Mask="false">376030</Config>
 </Container>

--- a/my-ARK12-Fjordur.xml
+++ b/my-ARK12-Fjordur.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <Container version="2">
-  <Name>ARK6-Valguero_P</Name>
+  <Name>ARK12-Fjordur</Name>
   <Repository>ich777/steamcmd:arkse</Repository>
   <Registry>https://hub.docker.com/r/ich777/steamcmd/</Registry>
   <Network>bridge</Network>
   <MyIP/>
-  <Shell>bash</Shell>
+  <Shell>sh</Shell>
   <Privileged>false</Privileged>
   <Support>https://forums.unraid.net/topic/79530-support-ich777-gameserver-dockers/</Support>
   <Project>https://survivetheark.com/</Project>
@@ -20,10 +20,10 @@ You can also run multiple servers with only one SteamCMD directory!</Overview>
   <WebUI/>
   <TemplateURL/>
   <Icon>https://raw.githubusercontent.com/ich777/docker-templates/master/ich777/images/arkse.png</Icon>
-  <ExtraParams>--restart=unless-stopped</ExtraParams>
+  <ExtraParams>--restart=unless-stopped </ExtraParams>
   <PostArgs/>
   <CPUset/>
-  <DateInstalled>1613444815</DateInstalled>
+  <DateInstalled>1613444660</DateInstalled>
   <DonateText>If you like my work please </DonateText>
   <DonateLink>https://www.paypal.me/chips777</DonateLink>
   <Description>This Docker will download and install SteamCMD. It will also install ARK:SurvivalEvolved and run it (Normal server startup of ARK can take a long time!).&#xD;
@@ -37,23 +37,23 @@ You can also run multiple servers with only one SteamCMD directory!</Description
     <Mode>bridge</Mode>
     <Publish>
       <Port>
-        <HostPort>7787</HostPort>
-        <ContainerPort>7787</ContainerPort>
+        <HostPort>7799</HostPort>
+        <ContainerPort>7799</ContainerPort>
         <Protocol>udp</Protocol>
       </Port>
       <Port>
-        <HostPort>7788</HostPort>
-        <ContainerPort>7788</ContainerPort>
+        <HostPort>7800</HostPort>
+        <ContainerPort>7800</ContainerPort>
         <Protocol>udp</Protocol>
       </Port>
       <Port>
-        <HostPort>27020</HostPort>
-        <ContainerPort>27020</ContainerPort>
+        <HostPort>27026</HostPort>
+        <ContainerPort>27026</ContainerPort>
         <Protocol>udp</Protocol>
       </Port>
       <Port>
-        <HostPort>27040</HostPort>
-        <ContainerPort>27040</ContainerPort>
+        <HostPort>27046</HostPort>
+        <ContainerPort>27046</ContainerPort>
         <Protocol>tcp</Protocol>
       </Port>
     </Publish>
@@ -70,12 +70,17 @@ You can also run multiple servers with only one SteamCMD directory!</Description
       <Mode>rw</Mode>
     </Volume>
     <Volume>
-      <HostDir>/mnt/cache/appdata/ark-se/ARK6-Valguero_P</HostDir>
+      <HostDir>/mnt/cache/appdata/ark-se/ARK12-Fjordur</HostDir>
       <ContainerDir>/serverdata/serverfiles/ShooterGame/Saved</ContainerDir>
       <Mode>rw</Mode>
     </Volume>
   </Data>
   <Environment>
+    <Variable>
+      <Value>376030</Value>
+      <Name>GAME_ID</Name>
+      <Mode/>
+    </Variable>
     <Variable>
       <Value/>
       <Name>USERNAME</Name>
@@ -92,12 +97,12 @@ You can also run multiple servers with only one SteamCMD directory!</Description
       <Mode/>
     </Variable>
     <Variable>
-      <Value>Valguero_P</Value>
+      <Value>Fjordur</Value>
       <Name>MAP</Name>
       <Mode/>
     </Variable>
     <Variable>
-      <Value>Your-Valguero</Value>
+      <Value>Your-Fjordur</Value>
       <Name>SERVER_NAME</Name>
       <Mode/>
     </Variable>
@@ -112,12 +117,12 @@ You can also run multiple servers with only one SteamCMD directory!</Description
       <Mode/>
     </Variable>
     <Variable>
-      <Value>?Port=7787?QueryPort=27020?MaxPlayers=10?RCONEnabled=True?RCONPort=27040?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
+      <Value>?Port=7799?QueryPort=27026?MaxPlayers=10?RCONEnabled=True?RCONPort=27046?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
       <Name>GAME_PARAMS</Name>
       <Mode/>
     </Variable>
     <Variable>
-      <Value>-server -log -nowrite -clusterid=YourCluster -ClusterDirOverride=/serverdata/serverfiles/clusterfiles -UseDynamicConfig </Value>
+      <Value>-server -log -clusterid=YourCluster -ClusterDirOverride=/serverdata/serverfiles/clusterfiles -UseDynamicConfig</Value>
       <Name>GAME_PARAMS_EXTRA</Name>
       <Mode/>
     </Variable>
@@ -131,31 +136,25 @@ You can also run multiple servers with only one SteamCMD directory!</Description
       <Name>GID</Name>
       <Mode/>
     </Variable>
-    <Variable>
-      <Value>376030</Value>
-      <Name>GAME_ID</Name>
-      <Mode/>
-    </Variable>
   </Environment>
   <Labels/>
   <Config Name="SteamCMD" Target="/serverdata/steamcmd" Default="" Mode="rw" Description="Container Path: /serverdata/steamcmd" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/steamcmd</Config>
   <Config Name="ServerFiles" Target="/serverdata/serverfiles" Default="" Mode="rw" Description="Container Path: /serverdata/serverfiles" Type="Path" Display="always" Required="true" Mask="false">/mnt/cache/appdata/ark-se</Config>
+  <Config Name="GAME_ID" Target="GAME_ID" Default="" Mode="" Description="The GAME_ID that the container download at startup.&#13;&#10;(https://developer.valvesoftware.com/wiki/Dedicated_Servers_List)" Type="Variable" Display="always" Required="true" Mask="false">376030</Config>
   <Config Name="Steam-Username" Target="USERNAME" Default="" Mode="" Description="Your Steam username goes here if you want to install a game that needs a valid account, otherwise leave it blank (ATTENTION: You have to disable Steam Guard)." Type="Variable" Display="always-hide" Required="false" Mask="false"/>
   <Config Name="Validate Installation" Target="VALIDATE" Default="" Mode="" Description="Set the Variable to 'true' if you want to validate the installation otherwise leave it blank." Type="Variable" Display="always-hide" Required="false" Mask="false"/>
   <Config Name="Steam-Password" Target="PASSWRD" Default="" Mode="" Description="Your Steam password goes here if you want to install a game that needs a valid account, otherwise leave it blank (ATTENTION: You have to disable Steam Guard)." Type="Variable" Display="always-hide" Required="false" Mask="true"/>
-  <Config Name="Map" Target="MAP" Default="TheIsland" Mode="" Description="Container Variable: MAP" Type="Variable" Display="always-hide" Required="true" Mask="false">Valguero_P</Config>
-  <Config Name="Server Name" Target="SERVER_NAME" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">Your-Valguero</Config>
+  <Config Name="Map" Target="MAP" Default="TheIsland" Mode="" Description="Container Variable: MAP" Type="Variable" Display="always-hide" Required="true" Mask="false">Fjordur</Config>
+  <Config Name="Server Name" Target="SERVER_NAME" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">Your-Fjordur</Config>
   <Config Name="Server Password" Target="SRV_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false"/>
   <Config Name="Server Admin Password" Target="SRV_ADMIN_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">NotMyPassword</Config>
-  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7787?QueryPort=27020?MaxPlayers=10?RCONEnabled=True?RCONPort=27040?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
-  <Config Name="Extra Game Parameters" Target="GAME_PARAMS_EXTRA" Default="" Mode="" Description="Type in your Extra Game Parameters seperated with a space and - (eg: -DisableDeathSpectator -UseBattlEye)" Type="Variable" Display="always-hide" Required="true" Mask="false">-server -log -nowrite -clusterid=YourCluster -ClusterDirOverride=/serverdata/serverfiles/clusterfiles -UseDynamicConfig </Config>
-  <Config Name="UDP 1" Target="7787" Default="" Mode="udp" Description="Container Port: 7787" Type="Port" Display="always" Required="false" Mask="false">7787</Config>
-  <Config Name="UDP 2" Target="7788" Default="" Mode="udp" Description="Container Port: 7788" Type="Port" Display="always" Required="false" Mask="false">7788</Config>
-  <Config Name="UDPSteam" Target="27020" Default="" Mode="udp" Description="Container Port: 27020" Type="Port" Display="always" Required="false" Mask="false">27020</Config>
-  <Config Name="TCPRCON" Target="27040" Default="" Mode="tcp" Description="Container Port: 27040" Type="Port" Display="always" Required="false" Mask="false">27040</Config>
-  <Config Name="ClusterID" Target="CLUSTERID" Default="" Mode="" Description="Name of the cluster this ARK should be a part of. &#13;&#10; Requires the ClusterFlies host path of all ARKs to be the same so they can pass player files back and forth." Type="Variable" Display="always" Required="false" Mask="false">YourCluster</Config>
-  <Config Name="ARK Save and Configs" Target="/serverdata/serverfiles/ShooterGame/Saved" Default="" Mode="rw" Description="container Path: /serverdata/serverfiles/ShooterGame/Saved &#13;&#10;A segregated space for separating ARK saves and  config ini's when creating a cluster example: /mnt/cache/appdata/ark-se/ARK1-TheIsland" Type="Path" Display="always" Required="false" Mask="false">/mnt/cache/appdata/ark-se/ARK6-Valguero_P</Config>
+  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7799?QueryPort=27026?MaxPlayers=10?RCONEnabled=True?RCONPort=27046?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
+  <Config Name="Extra Game Parameters" Target="GAME_PARAMS_EXTRA" Default="" Mode="" Description="Type in your Extra Game Parameters seperated with a space and - (eg: -DisableDeathSpectator -UseBattlEye)" Type="Variable" Display="always-hide" Required="true" Mask="false">-server -log  -clusterid=YourCluster -ClusterDirOverride=/serverdata/serverfiles/clusterfiles -UseDynamicConfig</Config>
+  <Config Name="UDP 1" Target="7779" Default="" Mode="udp" Description="Container Port: 7799" Type="Port" Display="always" Required="false" Mask="false">7799</Config>
+  <Config Name="UDP 2" Target="7780" Default="" Mode="udp" Description="Container Port: 7800" Type="Port" Display="always" Required="false" Mask="false">7800</Config>
+  <Config Name="UDPSteam" Target="27026" Default="" Mode="udp" Description="Container Port: 27026" Type="Port" Display="always" Required="false" Mask="false">27026</Config>
+  <Config Name="TCPRCON" Target="27046" Default="" Mode="tcp" Description="Container Port: 27046" Type="Port" Display="always" Required="false" Mask="false">27046</Config>
+  <Config Name="Saved" Target="/serverdata/serverfiles/ShooterGame/Saved" Default="" Mode="rw" Description="segregated space for saving arks and map specific config inis" Type="Path" Display="always" Required="false" Mask="false">/mnt/cache/appdata/ark-se/ARK12-Fjordur</Config>
   <Config Name="UID" Target="UID" Default="" Mode="" Description="Container Variable: UID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">99</Config>
   <Config Name="GID" Target="GID" Default="" Mode="" Description="Container Variable: GID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">100</Config>
-  <Config Name="GAME_ID" Target="GAME_ID" Default="" Mode="" Description="The GAME_ID that the container download at startup.&#13;&#10;(https://developer.valvesoftware.com/wiki/Dedicated_Servers_List)" Type="Variable" Display="advanced-hide" Required="true" Mask="false">376030</Config>
 </Container>

--- a/my-ARK2-ScorchedEarth_P.xml
+++ b/my-ARK2-ScorchedEarth_P.xml
@@ -52,8 +52,8 @@ You can also run multiple servers with only one SteamCMD directory!</Description
         <Protocol>udp</Protocol>
       </Port>
       <Port>
-        <HostPort>27026</HostPort>
-        <ContainerPort>27026</ContainerPort>
+        <HostPort>27036</HostPort>
+        <ContainerPort>27036</ContainerPort>
         <Protocol>tcp</Protocol>
       </Port>
     </Publish>
@@ -117,7 +117,7 @@ You can also run multiple servers with only one SteamCMD directory!</Description
       <Mode/>
     </Variable>
     <Variable>
-      <Value>?Port=7779?QueryPort=27016?MaxPlayers=10?RCONEnabled=True?RCONPort=27026?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
+      <Value>?Port=7779?QueryPort=27016?MaxPlayers=10?RCONEnabled=True?RCONPort=27036?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
       <Name>GAME_PARAMS</Name>
       <Mode/>
     </Variable>
@@ -148,12 +148,12 @@ You can also run multiple servers with only one SteamCMD directory!</Description
   <Config Name="Server Name" Target="SERVER_NAME" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">Your-ScorchedEarth</Config>
   <Config Name="Server Password" Target="SRV_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false"/>
   <Config Name="Server Admin Password" Target="SRV_ADMIN_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">NotMyPassword</Config>
-  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7779?QueryPort=27016?MaxPlayers=10?RCONEnabled=True?RCONPort=27026?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
+  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7779?QueryPort=27016?MaxPlayers=10?RCONEnabled=True?RCONPort=27036?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
   <Config Name="Extra Game Parameters" Target="GAME_PARAMS_EXTRA" Default="" Mode="" Description="Type in your Extra Game Parameters seperated with a space and - (eg: -DisableDeathSpectator -UseBattlEye)" Type="Variable" Display="always-hide" Required="true" Mask="false">-server -log  -clusterid=YourCluster -ClusterDirOverride=/serverdata/serverfiles/clusterfiles -UseDynamicConfig</Config>
   <Config Name="UDP 1" Target="7779" Default="" Mode="udp" Description="Container Port: 7779" Type="Port" Display="always" Required="false" Mask="false">7779</Config>
   <Config Name="UDP 2" Target="7780" Default="" Mode="udp" Description="Container Port: 7780" Type="Port" Display="always" Required="false" Mask="false">7780</Config>
   <Config Name="UDPSteam" Target="27016" Default="" Mode="udp" Description="Container Port: 27016" Type="Port" Display="always" Required="false" Mask="false">27016</Config>
-  <Config Name="TCPRCON" Target="27026" Default="" Mode="tcp" Description="Container Port: 27026" Type="Port" Display="always" Required="false" Mask="false">27026</Config>
+  <Config Name="TCPRCON" Target="27036" Default="" Mode="tcp" Description="Container Port: 27036" Type="Port" Display="always" Required="false" Mask="false">27036</Config>
   <Config Name="Saved" Target="/serverdata/serverfiles/ShooterGame/Saved" Default="" Mode="rw" Description="segregated space for saving arks and map specific config inis" Type="Path" Display="always" Required="false" Mask="false">/mnt/cache/appdata/ark-se/ARK2-ScorchedEarth_P</Config>
   <Config Name="UID" Target="UID" Default="" Mode="" Description="Container Variable: UID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">99</Config>
   <Config Name="GID" Target="GID" Default="" Mode="" Description="Container Variable: GID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">100</Config>

--- a/my-ARK3-Aberration_P.xml
+++ b/my-ARK3-Aberration_P.xml
@@ -52,8 +52,8 @@ You can also run multiple servers with only one SteamCMD directory!</Description
         <Protocol>udp</Protocol>
       </Port>
       <Port>
-        <HostPort>27027</HostPort>
-        <ContainerPort>27027</ContainerPort>
+        <HostPort>27037</HostPort>
+        <ContainerPort>27037</ContainerPort>
         <Protocol>tcp</Protocol>
       </Port>
     </Publish>
@@ -117,7 +117,7 @@ You can also run multiple servers with only one SteamCMD directory!</Description
       <Mode/>
     </Variable>
     <Variable>
-      <Value>?Port=7781?QueryPort=27017?MaxPlayers=10?RCONEnabled=True?RCONPort=27027?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
+      <Value>?Port=7781?QueryPort=27017?MaxPlayers=10?RCONEnabled=True?RCONPort=27037?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
       <Name>GAME_PARAMS</Name>
       <Mode/>
     </Variable>
@@ -148,12 +148,12 @@ You can also run multiple servers with only one SteamCMD directory!</Description
   <Config Name="Server Name" Target="SERVER_NAME" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">Your-Aberration</Config>
   <Config Name="Server Password" Target="SRV_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false"/>
   <Config Name="Server Admin Password" Target="SRV_ADMIN_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">NotMyPassword</Config>
-  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7781?QueryPort=27017?MaxPlayers=10?RCONEnabled=True?RCONPort=27027?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
+  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7781?QueryPort=27017?MaxPlayers=10?RCONEnabled=True?RCONPort=27037?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
   <Config Name="Extra Game Parameters" Target="GAME_PARAMS_EXTRA" Default="" Mode="" Description="Type in your Extra Game Parameters seperated with a space and - (eg: -DisableDeathSpectator -UseBattlEye)" Type="Variable" Display="always-hide" Required="true" Mask="false">-server -log -clusterid=YourCluster -ClusterDirOverride=/serverdata/serverfiles/clusterfiles -UseDynamicConfig</Config>
   <Config Name="UDP 1" Target="7781" Default="" Mode="udp" Description="Container Port: 7781" Type="Port" Display="always" Required="false" Mask="false">7781</Config>
   <Config Name="UDP 2" Target="7782" Default="" Mode="udp" Description="Container Port: 7782" Type="Port" Display="always" Required="false" Mask="false">7782</Config>
   <Config Name="UDPSteam" Target="27017" Default="" Mode="udp" Description="Container Port: 27017" Type="Port" Display="always" Required="false" Mask="false">27017</Config>
-  <Config Name="TCPRCON" Target="27027" Default="" Mode="tcp" Description="Container Port: 27027" Type="Port" Display="always" Required="false" Mask="false">27027</Config>
+  <Config Name="TCPRCON" Target="27037" Default="" Mode="tcp" Description="Container Port: 27037" Type="Port" Display="always" Required="false" Mask="false">27037</Config>
   <Config Name="Saved" Target="/serverdata/serverfiles/ShooterGame/Saved" Default="" Mode="rw" Description="segregated space for saving arks and map specific config inis" Type="Path" Display="always" Required="false" Mask="false">/mnt/cache/appdata/ark-se/ARK3-Aberration</Config>
   <Config Name="UID" Target="UID" Default="" Mode="" Description="Container Variable: UID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">99</Config>
   <Config Name="GID" Target="GID" Default="" Mode="" Description="Container Variable: GID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">100</Config>

--- a/my-ARK4-TheCenter.xml
+++ b/my-ARK4-TheCenter.xml
@@ -52,8 +52,8 @@ You can also run multiple servers with only one SteamCMD directory!</Description
         <Protocol>udp</Protocol>
       </Port>
       <Port>
-        <HostPort>27028</HostPort>
-        <ContainerPort>27028</ContainerPort>
+        <HostPort>27038</HostPort>
+        <ContainerPort>27038</ContainerPort>
         <Protocol>tcp</Protocol>
       </Port>
     </Publish>
@@ -117,7 +117,7 @@ You can also run multiple servers with only one SteamCMD directory!</Description
       <Mode/>
     </Variable>
     <Variable>
-      <Value>?Port=7783?QueryPort=27018?MaxPlayers=10?RCONEnabled=True?RCONPort=27028?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
+      <Value>?Port=7783?QueryPort=27018?MaxPlayers=10?RCONEnabled=True?RCONPort=27038?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
       <Name>GAME_PARAMS</Name>
       <Mode/>
     </Variable>
@@ -148,12 +148,12 @@ You can also run multiple servers with only one SteamCMD directory!</Description
   <Config Name="Server Name" Target="SERVER_NAME" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">Your-TheCenter</Config>
   <Config Name="Server Password" Target="SRV_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false"/>
   <Config Name="Server Admin Password" Target="SRV_ADMIN_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">NotMyPassword</Config>
-  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7783?QueryPort=27018?MaxPlayers=10?RCONEnabled=True?RCONPort=27028?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
+  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7783?QueryPort=27018?MaxPlayers=10?RCONEnabled=True?RCONPort=27038?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
   <Config Name="Extra Game Parameters" Target="GAME_PARAMS_EXTRA" Default="" Mode="" Description="Type in your Extra Game Parameters seperated with a space and - (eg: -DisableDeathSpectator -UseBattlEye)" Type="Variable" Display="always-hide" Required="true" Mask="false">-server -log -clusterid=YourCluster -ClusterDirOverride=/serverdata/serverfiles/clusterfiles -UseDynamicConfig</Config>
   <Config Name="UDP 1" Target="7783" Default="" Mode="udp" Description="Container Port: 7783" Type="Port" Display="always" Required="false" Mask="false">7783</Config>
   <Config Name="UDP 2" Target="7784" Default="" Mode="udp" Description="Container Port: 7784" Type="Port" Display="always" Required="false" Mask="false">7784</Config>
   <Config Name="UDPSteam" Target="27018" Default="" Mode="udp" Description="Container Port: 27018" Type="Port" Display="always" Required="false" Mask="false">27018</Config>
-  <Config Name="TCPRCON" Target="27028" Default="" Mode="tcp" Description="Container Port: 27028" Type="Port" Display="always" Required="false" Mask="false">27028</Config>
+  <Config Name="TCPRCON" Target="27038" Default="" Mode="tcp" Description="Container Port: 27038" Type="Port" Display="always" Required="false" Mask="false">27038</Config>
   <Config Name="Saved" Target="/serverdata/serverfiles/ShooterGame/Saved" Default="" Mode="rw" Description="container Path: /serverdata/serverfiles/ShooterGame/Saved a segregated space for saving arks and map specific config inis" Type="Path" Display="always" Required="false" Mask="false">/mnt/cache/appdata/ark-se/ARK4-TheCenter</Config>
   <Config Name="UID" Target="UID" Default="" Mode="" Description="Container Variable: UID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">99</Config>
   <Config Name="GID" Target="GID" Default="" Mode="" Description="Container Variable: GID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">100</Config>

--- a/my-ARK5-Ragnarok.xml
+++ b/my-ARK5-Ragnarok.xml
@@ -52,8 +52,8 @@ You can also run multiple servers with only one SteamCMD directory!</Description
         <Protocol>udp</Protocol>
       </Port>
       <Port>
-        <HostPort>27029</HostPort>
-        <ContainerPort>27029</ContainerPort>
+        <HostPort>27039</HostPort>
+        <ContainerPort>27039</ContainerPort>
         <Protocol>tcp</Protocol>
       </Port>
     </Publish>
@@ -117,7 +117,7 @@ You can also run multiple servers with only one SteamCMD directory!</Description
       <Mode/>
     </Variable>
     <Variable>
-      <Value>?Port=7785?QueryPort=27019?MaxPlayers=10?RCONEnabled=True?RCONPort=27029?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
+      <Value>?Port=7785?QueryPort=27019?MaxPlayers=10?RCONEnabled=True?RCONPort=27039?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
       <Name>GAME_PARAMS</Name>
       <Mode/>
     </Variable>
@@ -148,12 +148,12 @@ You can also run multiple servers with only one SteamCMD directory!</Description
   <Config Name="Server Name" Target="SERVER_NAME" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">Your-Ragnarok</Config>
   <Config Name="Server Password" Target="SRV_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false"/>
   <Config Name="Server Admin Password" Target="SRV_ADMIN_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">NotMyPassword</Config>
-  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7785?QueryPort=27019?MaxPlayers=10?RCONEnabled=True?RCONPort=27029?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
+  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7785?QueryPort=27019?MaxPlayers=10?RCONEnabled=True?RCONPort=27039?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
   <Config Name="Extra Game Parameters" Target="GAME_PARAMS_EXTRA" Default="" Mode="" Description="Type in your Extra Game Parameters seperated with a space and - (eg: -DisableDeathSpectator -UseBattlEye)" Type="Variable" Display="always-hide" Required="true" Mask="false">-server -log -clusterid=YourCluster -ClusterDirOverride=/serverdata/serverfiles/clusterfiles -UseDynamicConfig</Config>
   <Config Name="UDP 1" Target="7785" Default="" Mode="udp" Description="Container Port: 7785" Type="Port" Display="always" Required="false" Mask="false">7785</Config>
   <Config Name="UDP 2" Target="7786" Default="" Mode="udp" Description="Container Port: 7786" Type="Port" Display="always" Required="false" Mask="false">7786</Config>
   <Config Name="UDPSteam" Target="27019" Default="" Mode="udp" Description="Container Port: 27019" Type="Port" Display="always" Required="false" Mask="false">27019</Config>
-  <Config Name="TCPRCON" Target="27029" Default="" Mode="tcp" Description="Container Port: 27029" Type="Port" Display="always" Required="false" Mask="false">27029</Config>
+  <Config Name="TCPRCON" Target="27039" Default="" Mode="tcp" Description="Container Port: 27039" Type="Port" Display="always" Required="false" Mask="false">27039</Config>
   <Config Name="Saved" Target="/serverdata/serverfiles/ShooterGame/Saved" Default="" Mode="rw" Description="container Path: /serverdata/serverfiles/ShooterGame/Saved a segregated space for saving arks and map specific config inis" Type="Path" Display="always" Required="false" Mask="false">/mnt/cache/appdata/ark-se/ARK5-Ragnarok</Config>
   <Config Name="UID" Target="UID" Default="" Mode="" Description="Container Variable: UID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">99</Config>
   <Config Name="GID" Target="GID" Default="" Mode="" Description="Container Variable: GID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">100</Config>

--- a/my-ARK6-Valguero_P.xml
+++ b/my-ARK6-Valguero_P.xml
@@ -122,11 +122,6 @@ You can also run multiple servers with only one SteamCMD directory!</Description
       <Mode/>
     </Variable>
     <Variable>
-      <Value>YourCluster</Value>
-      <Name>CLUSTERID</Name>
-      <Mode/>
-    </Variable>
-    <Variable>
       <Value>99</Value>
       <Name>UID</Name>
       <Mode/>

--- a/my-ARK7-CrystalIsles.xml
+++ b/my-ARK7-CrystalIsles.xml
@@ -52,8 +52,8 @@ You can also run multiple servers with only one SteamCMD directory!</Description
         <Protocol>udp</Protocol>
       </Port>
       <Port>
-        <HostPort>27031</HostPort>
-        <ContainerPort>27031</ContainerPort>
+        <HostPort>27041</HostPort>
+        <ContainerPort>27041</ContainerPort>
         <Protocol>tcp</Protocol>
       </Port>
     </Publish>
@@ -117,7 +117,7 @@ You can also run multiple servers with only one SteamCMD directory!</Description
       <Mode/>
     </Variable>
     <Variable>
-      <Value>?Port=7789?QueryPort=27021?MaxPlayers=10?RCONEnabled=True?RCONPort=27031?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
+      <Value>?Port=7789?QueryPort=27021?MaxPlayers=10?RCONEnabled=True?RCONPort=27041?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
       <Name>GAME_PARAMS</Name>
       <Mode/>
     </Variable>
@@ -148,12 +148,12 @@ You can also run multiple servers with only one SteamCMD directory!</Description
   <Config Name="Server Name" Target="SERVER_NAME" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">Your-CrystalIsles</Config>
   <Config Name="Server Password" Target="SRV_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false"/>
   <Config Name="Server Admin Password" Target="SRV_ADMIN_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">NotMyPassword</Config>
-  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7789?QueryPort=27021?MaxPlayers=10?RCONEnabled=True?RCONPort=27031?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
+  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7789?QueryPort=27021?MaxPlayers=10?RCONEnabled=True?RCONPort=27041?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
   <Config Name="Extra Game Parameters" Target="GAME_PARAMS_EXTRA" Default="" Mode="" Description="Type in your Extra Game Parameters seperated with a space and - (eg: -DisableDeathSpectator -UseBattlEye)" Type="Variable" Display="always-hide" Required="true" Mask="false">-server -log -clusterid=YourCluster -ClusterDirOverride=/serverdata/serverfiles/clusterfiles -UseDynamicConfig</Config>
   <Config Name="UDP 1" Target="7789" Default="" Mode="udp" Description="Container Port: 7789" Type="Port" Display="always" Required="false" Mask="false">7789</Config>
   <Config Name="UDP 2" Target="7790" Default="" Mode="udp" Description="Container Port: 7790" Type="Port" Display="always" Required="false" Mask="false">7790</Config>
   <Config Name="UDPSteam" Target="27021" Default="" Mode="udp" Description="Container Port: 27021" Type="Port" Display="always" Required="false" Mask="false">27021</Config>
-  <Config Name="TCPRCON" Target="27031" Default="" Mode="tcp" Description="Container Port: 27031" Type="Port" Display="always" Required="false" Mask="false">27031</Config>
+  <Config Name="TCPRCON" Target="27041" Default="" Mode="tcp" Description="Container Port: 27041" Type="Port" Display="always" Required="false" Mask="false">27041</Config>
   <Config Name="Saved" Target="/serverdata/serverfiles/ShooterGame/Saved" Default="" Mode="rw" Description="container Path: /serverdata/serverfiles/ShooterGame/Saved a segregated space for saving arks and map specific config inis" Type="Path" Display="always" Required="false" Mask="false">/mnt/cache/appdata/ark-se/ARK7-CrystalIsles</Config>
   <Config Name="UID" Target="UID" Default="" Mode="" Description="Container Variable: UID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">99</Config>
   <Config Name="GID" Target="GID" Default="" Mode="" Description="Container Variable: GID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">100</Config>

--- a/my-ARK8-Extinction.xml
+++ b/my-ARK8-Extinction.xml
@@ -52,8 +52,8 @@ You can also run multiple servers with only one SteamCMD directory!</Description
         <Protocol>udp</Protocol>
       </Port>
       <Port>
-        <HostPort>27032</HostPort>
-        <ContainerPort>27032</ContainerPort>
+        <HostPort>27042</HostPort>
+        <ContainerPort>27042</ContainerPort>
         <Protocol>tcp</Protocol>
       </Port>
     </Publish>
@@ -117,7 +117,7 @@ You can also run multiple servers with only one SteamCMD directory!</Description
       <Mode/>
     </Variable>
     <Variable>
-      <Value>?Port=7791?QueryPort=27022?MaxPlayers=10?RCONEnabled=True?RCONPort=27032?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
+      <Value>?Port=7791?QueryPort=27022?MaxPlayers=10?RCONEnabled=True?RCONPort=27042?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
       <Name>GAME_PARAMS</Name>
       <Mode/>
     </Variable>
@@ -148,12 +148,12 @@ You can also run multiple servers with only one SteamCMD directory!</Description
   <Config Name="Server Name" Target="SERVER_NAME" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">Your-Extinction</Config>
   <Config Name="Server Password" Target="SRV_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false"/>
   <Config Name="Server Admin Password" Target="SRV_ADMIN_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">NotMyPassword</Config>
-  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7791?QueryPort=27022?MaxPlayers=10?RCONEnabled=True?RCONPort=27032?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
+  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7791?QueryPort=27022?MaxPlayers=10?RCONEnabled=True?RCONPort=27042?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
   <Config Name="Extra Game Parameters" Target="GAME_PARAMS_EXTRA" Default="" Mode="" Description="Type in your Extra Game Parameters seperated with a space and - (eg: -DisableDeathSpectator -UseBattlEye)" Type="Variable" Display="always-hide" Required="true" Mask="false">-server -log -clusterid=YourCluster -ClusterDirOverride=/serverdata/serverfiles/clusterfiles -UseDynamicConfig</Config>
   <Config Name="UDP 1" Target="7791" Default="" Mode="udp" Description="Container Port: 7791" Type="Port" Display="always" Required="false" Mask="false">7791</Config>
   <Config Name="UDP 2" Target="7792" Default="" Mode="udp" Description="Container Port: 7792" Type="Port" Display="always" Required="false" Mask="false">7792</Config>
   <Config Name="UDPSteam" Target="27022" Default="" Mode="udp" Description="Container Port: 27022" Type="Port" Display="always" Required="false" Mask="false">27022</Config>
-  <Config Name="TCPRCON" Target="27032" Default="" Mode="tcp" Description="Container Port: 27032" Type="Port" Display="always" Required="false" Mask="false">27032</Config>
+  <Config Name="TCPRCON" Target="27042" Default="" Mode="tcp" Description="Container Port: 27042" Type="Port" Display="always" Required="false" Mask="false">27042</Config>
   <Config Name="Saved" Target="/serverdata/serverfiles/ShooterGame/Saved" Default="" Mode="rw" Description="container Path: /serverdata/serverfiles/ShooterGame/Saved a segregated space for saving arks and map specific config inis" Type="Path" Display="always" Required="false" Mask="false">/mnt/cache/appdata/ark-se/ARK8-Extinction</Config>
   <Config Name="UID" Target="UID" Default="" Mode="" Description="Container Variable: UID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">99</Config>
   <Config Name="GID" Target="GID" Default="" Mode="" Description="Container Variable: GID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">100</Config>

--- a/my-ARK9-Genesis.xml
+++ b/my-ARK9-Genesis.xml
@@ -52,8 +52,8 @@ You can also run multiple servers with only one SteamCMD directory!</Description
         <Protocol>udp</Protocol>
       </Port>
       <Port>
-        <HostPort>27033</HostPort>
-        <ContainerPort>27033</ContainerPort>
+        <HostPort>27043</HostPort>
+        <ContainerPort>27043</ContainerPort>
         <Protocol>tcp</Protocol>
       </Port>
     </Publish>
@@ -117,7 +117,7 @@ You can also run multiple servers with only one SteamCMD directory!</Description
       <Mode/>
     </Variable>
     <Variable>
-      <Value>?Port=7793?QueryPort=27023?MaxPlayers=10?RCONEnabled=True?RCONPort=27033?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
+      <Value>?Port=7793?QueryPort=27023?MaxPlayers=10?RCONEnabled=True?RCONPort=27043?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Value>
       <Name>GAME_PARAMS</Name>
       <Mode/>
     </Variable>
@@ -148,12 +148,12 @@ You can also run multiple servers with only one SteamCMD directory!</Description
   <Config Name="Server Name" Target="SERVER_NAME" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">Your-Genesis</Config>
   <Config Name="Server Password" Target="SRV_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false"/>
   <Config Name="Server Admin Password" Target="SRV_ADMIN_PWD" Default="" Mode="" Description="Leave empty if you want to use the settings from GameUserSettings.ini (this field accepts no spaces)" Type="Variable" Display="always-hide" Required="false" Mask="false">NotMyPassword</Config>
-  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7793?QueryPort=27023?MaxPlayers=10?RCONEnabled=True?RCONPort=27033?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
+  <Config Name="Game Parameters" Target="GAME_PARAMS" Default="" Mode="" Description="Enter your game parameters seperated with ? and start with a ? (don't put spaces in between eg: ?MaxPlayers=40?FastDecayUnsnappedCoreStructures=true)" Type="Variable" Display="always-hide" Required="false" Mask="false">?Port=7793?QueryPort=27023?MaxPlayers=10?RCONEnabled=True?RCONPort=27043?customdynamicconfigurl="http://172.17.0.2/dynamicconfig.ini"</Config>
   <Config Name="Extra Game Parameters" Target="GAME_PARAMS_EXTRA" Default="" Mode="" Description="Type in your Extra Game Parameters seperated with a space and - (eg: -DisableDeathSpectator -UseBattlEye)" Type="Variable" Display="always-hide" Required="true" Mask="false">-server -log -clusterid=YourCluster -ClusterDirOverride=/serverdata/serverfiles/clusterfiles -UseDynamicConfig</Config>
   <Config Name="UDP 1" Target="7793" Default="" Mode="udp" Description="Container Port: 7793" Type="Port" Display="always" Required="false" Mask="false">7793</Config>
   <Config Name="UDP 2" Target="7794" Default="" Mode="udp" Description="Container Port: 7794" Type="Port" Display="always" Required="false" Mask="false">7794</Config>
   <Config Name="UDPSteam" Target="27023" Default="" Mode="udp" Description="Container Port: 27023" Type="Port" Display="always" Required="false" Mask="false">27023</Config>
-  <Config Name="TCPRCON" Target="27033" Default="" Mode="tcp" Description="Container Port: 27033" Type="Port" Display="always" Required="false" Mask="false">27033</Config>
+  <Config Name="TCPRCON" Target="27043" Default="" Mode="tcp" Description="Container Port: 27043" Type="Port" Display="always" Required="false" Mask="false">27043</Config>
   <Config Name="Saved" Target="/serverdata/serverfiles/ShooterGame/Saved" Default="" Mode="rw" Description="container Path: /serverdata/serverfiles/ShooterGame/Saved a segregated space for saving arks and map specific config inis" Type="Path" Display="always" Required="false" Mask="false">/mnt/cache/appdata/ark-se/ARK9-Genesis</Config>
   <Config Name="UID" Target="UID" Default="" Mode="" Description="Container Variable: UID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">99</Config>
   <Config Name="GID" Target="GID" Default="" Mode="" Description="Container Variable: GID" Type="Variable" Display="advanced-hide" Required="true" Mask="false">100</Config>

--- a/start.sh
+++ b/start.sh
@@ -14,6 +14,13 @@ if [ ! -f $FILE ];then
 		echo $i >> /serverdata/serverfiles/dynamicconfig/ARK-list.txt
 	done
 	echo "dynamicconfig" >> /serverdata/serverfiles/dynamicconfig/ARK-list.txt
+else
+        echo -n > /serverdata/serverfiles/dynamicconfig/ARK-list.txt
+        IFS=',' read -ra ADDR <<< "$CONTAINER_NAMES"
+        for i in "${ADDR[@]}"; do
+                echo $i >> /serverdata/serverfiles/dynamicconfig/ARK-list.txt
+        done
+        echo  "dynamicconfig" >> /serverdata/serverfiles/dynamicconfig/ARK-list.txt
 fi
 FILE=/serverdata/serverfiles/dynamicconfig/BackupARK.sh
 if [ ! -f $FILE ];then


### PR DESCRIPTION
Added templates for the missing maps. Comes with a change to the RCON Ports since we circle jerked over the 10 Server overlap, so i just moved to ports 10 further.

Fixed up the start.sh. It was really odd that you had to specify the Docker-Container in during the deployment and then, if you already had it running before, had to edit the ARK-list.txt by hand. Now does it automatically after changing the names during deployment.