### PR TITLE
Update to start.sh to check .txt for any changes. Fixed python not able to interact with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python3-pip \
     cron \
     nano
-
+RUN pip3 install requests==2.28.1
 WORKDIR /
 
 ADD requirements.txt /requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python3-pip \
     cron \
     nano
-RUN pip3 install requests==2.28.1
+
 WORKDIR /
 
 ADD requirements.txt /requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 docker==4.4.1
+urllib3<2

--- a/start.sh
+++ b/start.sh
@@ -7,12 +7,25 @@ FILE=/serverdata/serverfiles/dynamicconfig/steam.crontab
 if [ ! -f $FILE ];then
 cp /opt/scripts/steam.crontab /serverdata/serverfiles/dynamicconfig/steam.crontab
 fi
-echo -n > /serverdata/serverfiles/dynamicconfig/ARK-list.txt
-IFS=',' read -ra ADDR <<< "$CONTAINER_NAMES"
-for i in "${ADDR[@]}"; do
-        echo $i >> /serverdata/serverfiles/dynamicconfig/ARK-list.txt
-done
-echo  "dynamicconfig" >> /serverdata/serverfiles/dynamicconfig/ARK-list.txt
+FILE=/serverdata/serverfiles/dynamicconfig/ARK-list.txt
+if [ ! -f $FILE ];then
+        IFS=',' read -ra ADDR <<< "$CONTAINER_NAMES"
+        for i in "${ADDR[@]}"; do
+                echo $i >> /serverdata/serverfiles/dynamicconfig/ARK-list.txt
+        done
+        echo "dynamicconfig" >> /serverdata/serverfiles/dynamicconfig/ARK-list.txt
+else
+        IFS=',' read -ra ADDR <<< "$CONTAINER_NAMES"
+        IFS=$'\n' read -d '' -ra ARKLIST < /serverdata/serverfiles/dynamicconfig/ARK-list.txt
+
+        if [[ "${ADDR[@]} dynamicconfig" != "${ARKLIST[@]}" ]]; then
+        echo -n > /serverdata/serverfiles/dynamicconfig/ARK-list.txt
+        for i in "${ADDR[@]}"; do
+                echo $i >> /serverdata/serverfiles/dynamicconfig/ARK-list.txt
+        done
+        echo  "dynamicconfig" >> /serverdata/serverfiles/dynamicconfig/ARK-list.txt
+        fi
+fi
 FILE=/serverdata/serverfiles/dynamicconfig/BackupARK.sh
 if [ ! -f $FILE ];then
 cp /opt/scripts/BackupARK.sh /serverdata/serverfiles/dynamicconfig/BackupARK.sh

--- a/start.sh
+++ b/start.sh
@@ -7,21 +7,12 @@ FILE=/serverdata/serverfiles/dynamicconfig/steam.crontab
 if [ ! -f $FILE ];then
 cp /opt/scripts/steam.crontab /serverdata/serverfiles/dynamicconfig/steam.crontab
 fi
-FILE=/serverdata/serverfiles/dynamicconfig/ARK-list.txt
-if [ ! -f $FILE ];then
-	IFS=',' read -ra ADDR <<< "$CONTAINER_NAMES"
-	for i in "${ADDR[@]}"; do
-		echo $i >> /serverdata/serverfiles/dynamicconfig/ARK-list.txt
-	done
-	echo "dynamicconfig" >> /serverdata/serverfiles/dynamicconfig/ARK-list.txt
-else
-        echo -n > /serverdata/serverfiles/dynamicconfig/ARK-list.txt
-        IFS=',' read -ra ADDR <<< "$CONTAINER_NAMES"
-        for i in "${ADDR[@]}"; do
-                echo $i >> /serverdata/serverfiles/dynamicconfig/ARK-list.txt
-        done
-        echo  "dynamicconfig" >> /serverdata/serverfiles/dynamicconfig/ARK-list.txt
-fi
+echo -n > /serverdata/serverfiles/dynamicconfig/ARK-list.txt
+IFS=',' read -ra ADDR <<< "$CONTAINER_NAMES"
+for i in "${ADDR[@]}"; do
+        echo $i >> /serverdata/serverfiles/dynamicconfig/ARK-list.txt
+done
+echo  "dynamicconfig" >> /serverdata/serverfiles/dynamicconfig/ARK-list.txt
 FILE=/serverdata/serverfiles/dynamicconfig/BackupARK.sh
 if [ ! -f $FILE ];then
 cp /opt/scripts/BackupARK.sh /serverdata/serverfiles/dynamicconfig/BackupARK.sh


### PR DESCRIPTION
The last change for automatic updates could have just been a constant rewrite of the Ark-list.txt without the need of if-statements at all. Now the container reads the environment variables and compares against the text file for changes and if nothing changed, leaves the file alone, reducing any need to write (which i love).



Added urllib3<2 to the requirements so that the python script is able to interact with docker again